### PR TITLE
Unrecognized field "currentItemId" on MediaStatus

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/Item.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Item.java
@@ -1,0 +1,22 @@
+package su.litvak.chromecast.api.v2;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+public class Item {
+
+    public final boolean autoplay;
+    public final Object customData;
+    public final Media media;
+    public final int itemId;
+
+    public Item (@JsonProperty("autoplay") boolean autoplay,
+            @JsonProperty("customData") Object customData,
+            @JsonProperty("itemId") int itemId,
+            @JsonProperty("media") Media media) {
+        this.autoplay = autoplay;
+        this.customData = customData;
+        this.itemId = itemId;
+        this.media = media;
+    }
+
+}

--- a/src/main/java/su/litvak/chromecast/api/v2/Item.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Item.java
@@ -1,22 +1,48 @@
 package su.litvak.chromecast.api.v2;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
 import org.codehaus.jackson.annotate.JsonProperty;
 
 public class Item {
 
     public final boolean autoplay;
-    public final Object customData;
+    public final Map<String, Object> customData;
     public final Media media;
     public final int itemId;
 
     public Item (@JsonProperty("autoplay") boolean autoplay,
-            @JsonProperty("customData") Object customData,
+            @JsonProperty("customData") Map<String, Object> customData,
             @JsonProperty("itemId") int itemId,
             @JsonProperty("media") Media media) {
         this.autoplay = autoplay;
-        this.customData = customData;
+        this.customData = customData != null ? Collections.unmodifiableMap(customData) : null;
         this.itemId = itemId;
         this.media = media;
+    }
+
+    @Override
+    public int hashCode () {
+        return Arrays.hashCode(new Object[] { this.autoplay, this.customData, this.itemId, this.media });
+    }
+
+    @Override
+    public boolean equals (final Object obj) {
+        if (obj == null) return false;
+        if (obj == this) return true;
+        if (!(obj instanceof Item)) return false;
+        final Item that = (Item) obj;
+        return this.autoplay == that.autoplay &&
+                this.customData == null ? that.customData == null : this.customData.equals(that.customData) &&
+                this.itemId == that.itemId &&
+                this.media == null ? that.media == null : this.media.equals(that.media);
+    }
+
+    @Override
+    public String toString () {
+        return String.format("Item{%s, %s}", this.itemId, this.media);
     }
 
 }

--- a/src/main/java/su/litvak/chromecast/api/v2/Media.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Media.java
@@ -15,6 +15,8 @@
  */
 package su.litvak.chromecast.api.v2;
 
+import java.util.Arrays;
+
 import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
@@ -30,9 +32,38 @@ public class Media {
     @JsonProperty
     public Double duration;
 
+    public Media(String url, String contentType) {
+        this(url, contentType, null);
+    }
+
     public Media(@JsonProperty("contentId") String url,
-                 @JsonProperty("contentType") String contentType) {
+                 @JsonProperty("contentType") String contentType,
+                 @JsonProperty("duration") Double duration) {
         this.url = url;
         this.contentType = contentType;
+        this.duration = duration;
     }
+
+    @Override
+    public int hashCode () {
+        return Arrays.hashCode(new Object[] { this.url, this.contentType, this.streamType, this.duration });
+    }
+
+    @Override
+    public boolean equals (final Object obj) {
+        if (obj == null) return false;
+        if (obj == this) return true;
+        if (!(obj instanceof Media)) return false;
+        final Media that = (Media) obj;
+        return this.url == null ? that.url == null : this.url.equals(that.url) &&
+                this.contentType == null ? that.contentType == null : this.contentType.equals(that.contentType) &&
+                this.streamType == null ? that.streamType == null : this.streamType.equals(that.streamType) &&
+                this.duration == null ? that.duration == null : this.duration.equals(that.duration);
+    }
+
+    @Override
+    public String toString () {
+        return String.format("Media{%s, %s, %s}", this.url, this.contentType, this.duration);
+    }
+
 }

--- a/src/main/java/su/litvak/chromecast/api/v2/MediaStatus.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/MediaStatus.java
@@ -15,43 +15,58 @@
  */
 package su.litvak.chromecast.api.v2;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import java.util.Collections;
+import java.util.List;
+
 import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
  * Current media player status - which media is played, volume, time position, etc.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class MediaStatus {
     /**
      * Playback status
      */
     public enum PlayerState { IDLE, BUFFERING, PLAYING, PAUSED }
 
+    /**
+     * https://developers.google.com/cast/docs/reference/receiver/cast.receiver.media#.repeatMode
+     */
+    public enum RepeatMode { REPEAT_OFF, REPEAT_ALL, REPEAT_SINGLE, REPEAT_ALL_AND_SHUFFLE }
+
     public final long mediaSessionId;
     public final int playbackRate;
     public final PlayerState playerState;
+    public final int currentItemId;
     public final float currentTime;
+    public final List<Item> items;
     public final int supportedMediaCommands;
     public final Volume volume;
     public final Media media;
+    public final RepeatMode repeatMode;
     public final String idleReason;
 
     MediaStatus(@JsonProperty("mediaSessionId") long mediaSessionId,
                        @JsonProperty("playbackRate") int playbackRate,
                        @JsonProperty("playerState") PlayerState playerState,
+                       @JsonProperty("currentItemId") int currentItemId,
                        @JsonProperty("currentTime") float currentTime,
+                       @JsonProperty("items") List<Item> items,
                        @JsonProperty("supportedMediaCommands") int supportedMediaCommands,
                        @JsonProperty("volume") Volume volume,
                        @JsonProperty("media") Media media,
+                       @JsonProperty("repeatMode") RepeatMode repeatMode,
                        @JsonProperty("idleReason") String idleReason) {
         this.mediaSessionId = mediaSessionId;
         this.playbackRate = playbackRate;
         this.playerState = playerState;
+        this.currentItemId = currentItemId;
         this.currentTime = currentTime;
+        this.items = items != null ? Collections.unmodifiableList(items) : null;
         this.supportedMediaCommands = supportedMediaCommands;
         this.volume = volume;
         this.media = media;
+        this.repeatMode = repeatMode;
         this.idleReason = idleReason;
     }
 }

--- a/src/main/java/su/litvak/chromecast/api/v2/MediaStatus.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/MediaStatus.java
@@ -17,6 +17,7 @@ package su.litvak.chromecast.api.v2;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 
@@ -34,35 +35,47 @@ public class MediaStatus {
      */
     public enum RepeatMode { REPEAT_OFF, REPEAT_ALL, REPEAT_SINGLE, REPEAT_ALL_AND_SHUFFLE }
 
+    public final List<Integer> activeTrackIds;
     public final long mediaSessionId;
     public final int playbackRate;
     public final PlayerState playerState;
     public final Integer currentItemId;
     public final float currentTime;
+    public final Map<String, Object> customData;
+    public final Integer loadingItemId;
     public final List<Item> items;
+    public final Integer preloadedItemId;
     public final int supportedMediaCommands;
     public final Volume volume;
     public final Media media;
     public final RepeatMode repeatMode;
     public final String idleReason;
 
-    MediaStatus(@JsonProperty("mediaSessionId") long mediaSessionId,
+    MediaStatus(@JsonProperty("activeTrackIds") List<Integer> activeTrackIds,
+                       @JsonProperty("mediaSessionId") long mediaSessionId,
                        @JsonProperty("playbackRate") int playbackRate,
                        @JsonProperty("playerState") PlayerState playerState,
                        @JsonProperty("currentItemId") Integer currentItemId,
                        @JsonProperty("currentTime") float currentTime,
+                       @JsonProperty("customData") Map<String, Object> customData,
+                       @JsonProperty("loadingItemId") Integer loadingItemId,
                        @JsonProperty("items") List<Item> items,
+                       @JsonProperty("preloadedItemId") Integer preloadedItemId,
                        @JsonProperty("supportedMediaCommands") int supportedMediaCommands,
                        @JsonProperty("volume") Volume volume,
                        @JsonProperty("media") Media media,
                        @JsonProperty("repeatMode") RepeatMode repeatMode,
                        @JsonProperty("idleReason") String idleReason) {
+        this.activeTrackIds = activeTrackIds != null ? Collections.unmodifiableList(activeTrackIds) : null;
         this.mediaSessionId = mediaSessionId;
         this.playbackRate = playbackRate;
         this.playerState = playerState;
         this.currentItemId = currentItemId;
         this.currentTime = currentTime;
+        this.customData = customData != null ? Collections.unmodifiableMap(customData) : null;
+        this.loadingItemId = loadingItemId;
         this.items = items != null ? Collections.unmodifiableList(items) : null;
+        this.preloadedItemId = preloadedItemId;
         this.supportedMediaCommands = supportedMediaCommands;
         this.volume = volume;
         this.media = media;

--- a/src/main/java/su/litvak/chromecast/api/v2/MediaStatus.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/MediaStatus.java
@@ -15,11 +15,13 @@
  */
 package su.litvak.chromecast.api.v2;
 
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
  * Current media player status - which media is played, volume, time position, etc.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class MediaStatus {
     /**
      * Playback status

--- a/src/main/java/su/litvak/chromecast/api/v2/MediaStatus.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/MediaStatus.java
@@ -37,7 +37,7 @@ public class MediaStatus {
     public final long mediaSessionId;
     public final int playbackRate;
     public final PlayerState playerState;
-    public final int currentItemId;
+    public final Integer currentItemId;
     public final float currentTime;
     public final List<Item> items;
     public final int supportedMediaCommands;
@@ -49,7 +49,7 @@ public class MediaStatus {
     MediaStatus(@JsonProperty("mediaSessionId") long mediaSessionId,
                        @JsonProperty("playbackRate") int playbackRate,
                        @JsonProperty("playerState") PlayerState playerState,
-                       @JsonProperty("currentItemId") int currentItemId,
+                       @JsonProperty("currentItemId") Integer currentItemId,
                        @JsonProperty("currentTime") float currentTime,
                        @JsonProperty("items") List<Item> items,
                        @JsonProperty("supportedMediaCommands") int supportedMediaCommands,

--- a/src/main/java/su/litvak/chromecast/api/v2/Volume.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Volume.java
@@ -15,6 +15,8 @@
  */
 package su.litvak.chromecast.api.v2;
 
+import java.util.Arrays;
+
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 
@@ -33,4 +35,25 @@ public class Volume {
         this.level = level;
         this.muted = muted;
     }
+
+    @Override
+    public int hashCode () {
+        return Arrays.hashCode(new Object[] { this.level, this.muted });
+    }
+
+    @Override
+    public boolean equals (final Object obj) {
+        if (obj == null) return false;
+        if (obj == this) return true;
+        if (!(obj instanceof Volume)) return false;
+        final Volume that = (Volume) obj;
+        return this.level == null ? that.level == null : this.level.equals(that.level) &&
+                this.muted == that.muted;
+    }
+
+    @Override
+    public String toString () {
+        return String.format("Volue{%s, %s}", this.level, this.muted);
+    }
+
 }

--- a/src/test/java/su/litvak/chromecast/api/v2/MediaStatusTest.java
+++ b/src/test/java/su/litvak/chromecast/api/v2/MediaStatusTest.java
@@ -17,8 +17,19 @@ package su.litvak.chromecast.api.v2;
 
 import static org.junit.Assert.*;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
+
+import su.litvak.chromecast.api.v2.MediaStatus.PlayerState;
+import su.litvak.chromecast.api.v2.MediaStatus.RepeatMode;
 
 public class MediaStatusTest {
     final ObjectMapper jsonMapper = new ObjectMapper();
@@ -38,4 +49,50 @@ public class MediaStatusTest {
         MediaStatus mediaStatus = response.statuses[0];
         assertNull(mediaStatus.idleReason);
     }
+
+    @Test
+    public void testDeserializationWithChromeCastAudioFixture () throws Exception {
+        final String jsonMSG = fixtureAsString("/mediaStatus-chromecast-audio.json").replaceFirst("\"type\"", "\"responseType\"");
+        final Response.MediaStatus response = (Response.MediaStatus) jsonMapper.readValue(jsonMSG, Response.class);
+        assertEquals(1, response.statuses.length);
+        final MediaStatus mediaStatus = response.statuses[0];
+        assertEquals((Integer) 1, mediaStatus.currentItemId);
+        assertEquals(0f, mediaStatus.currentTime, 0f);
+
+        final Media media = new Media("http://192.168.1.6:8192/audio-123-mp3", "audio/mpeg", 389.355102d);
+
+        final Map<String, String> payload = new HashMap<String, String>();
+        payload.put("thumb", null);
+        payload.put("title", "Example Track Title");
+        final Map<String, Object> customData = new HashMap<String, Object>();
+        customData.put("payload", payload);
+        assertEquals(Arrays.asList(new Item[] {
+                new Item(true, customData, 1, media)
+        }), mediaStatus.items);
+
+        assertEquals(media, mediaStatus.media);
+        assertEquals(1, mediaStatus.mediaSessionId);
+        assertEquals(1, mediaStatus.playbackRate);
+        assertEquals(PlayerState.BUFFERING, mediaStatus.playerState);
+        assertEquals(RepeatMode.REPEAT_OFF, mediaStatus.repeatMode);
+        assertEquals(15, mediaStatus.supportedMediaCommands);
+        assertEquals(new Volume(1f, false), mediaStatus.volume);
+    }
+
+    private String fixtureAsString (final String res) throws IOException {
+        final InputStream is = getClass().getResourceAsStream(res);
+        try {
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+            final StringBuilder sb = new StringBuilder();
+            String line = null;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line).append("\n");
+            }
+            return sb.toString();
+        }
+        finally {
+            is.close();
+        }
+    }
+
 }

--- a/src/test/resources/mediaStatus-chromecast-audio.json
+++ b/src/test/resources/mediaStatus-chromecast-audio.json
@@ -1,0 +1,43 @@
+{
+    "requestId": 3,
+    "status": [
+        {
+            "currentItemId": 1,
+            "currentTime": 0,
+            "items": [
+                {
+                    "autoplay": true,
+                    "customData": {
+                        "payload": {
+                            "thumb": null,
+                            "title:": "Example Track Title"
+                        }
+                    },
+                    "itemId": 1,
+                    "media": {
+                        "contentId": "http://192.168.1.6:8192/audio-123-mp3",
+                        "contentType": "audio/mpeg",
+                        "duration": 389.355102,
+                        "streamType": "buffered"
+                    }
+                }
+            ],
+            "media": {
+                "contentId": "http://192.168.1.6:8192/audio-123-mp3",
+                "contentType": "audio/mpeg",
+                "duration": 389.355102,
+                "streamType": "buffered"
+            },
+            "mediaSessionId": 1,
+            "playbackRate": 1,
+            "playerState": "BUFFERING",
+            "repeatMode": "REPEAT_OFF",
+            "supportedMediaCommands": 15,
+            "volume": {
+                "level": 1,
+                "muted": false
+            }
+        }
+    ],
+    "type": "MEDIA_STATUS"
+}


### PR DESCRIPTION
When trying to play a MP3 file through a Chromecast Audio,
the file starts paying,
but `chromecast.getMediaStatus()` seems to break with this:
```
12:15:19.150 [  Thread-2]      s.l.c.api.v2.Channel W Error while reading: Unrecognized field "currentItemId" (Class su.litvak.chromecast.api.v2.MediaStatus), not marked as ignorable
 at [Source: java.io.StringReader@b71498; line: 1, column: 826] (through reference chain: su.litvak.chromecast.api.v2.MediaStatus["currentItemId"])
```

The docs ( https://developers.google.com/cast/docs/reference/receiver/cast.receiver.media.MediaStatus ) describe this field:

"currentItemId
(number or undefined)
ID of this media item (the item that originated the status change)."

I guess it is something to do with playlists, but since the rest of the library currently does not know about `ItemId`, its not much use on its own.
So for now adding `@JsonIgnoreProperties(ignoreUnknown = true)` to `MediaStatus` works around the issue and makes it less brittle to API changes.

p.s. Thanks for creating this library - it looks like just what I need for my next project. :D