### PR TITLE
Added support for DashCast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@ out
 target
 *.iml
 .idea
-
+.classpath
+.project
+.settings/
 *.class
 
 # Mobile Tools for Java (J2ME)

--- a/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
@@ -291,13 +291,10 @@ public class ChromeCast implements Closeable {
 
 		Application runningApp = status.getRunningApp();
 
-		// Load the DashCast receiver if it's not already running
-		if (!isAppRunning(DASHCAST_APP_ID)) {
-			LOG.debug("Starting DashCast");
-			runningApp = launchApp(DASHCAST_APP_ID);
-			if (runningApp == null) {
-				throw new RuntimeException("Unable load DashCast app, id: " + DASHCAST_APP_ID);
-			}
+		LOG.debug("(Re)loading the DashCast receiver");
+		runningApp = launchApp(DASHCAST_APP_ID);
+		if (runningApp == null) {
+			throw new RuntimeException("Unable load DashCast app, id: " + DASHCAST_APP_ID);
 		}
 
 		channel.castUrl(runningApp.transportId, url.toString(), force, reloadTimeMs != null, reloadTimeMs == null ? 0 : reloadTimeMs);

--- a/src/main/java/su/litvak/chromecast/api/v2/Message.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Message.java
@@ -35,7 +35,8 @@ import org.codehaus.jackson.map.annotate.JsonSerialize;
                @JsonSubTypes.Type(name = "PLAY", value = Request.Play.class),
                @JsonSubTypes.Type(name = "PAUSE", value = Request.Pause.class),
                @JsonSubTypes.Type(name = "SET_VOLUME", value = Request.SetVolume.class),
-               @JsonSubTypes.Type(name = "SEEK", value = Request.Seek.class)})
+               @JsonSubTypes.Type(name = "SEEK", value = Request.Seek.class),
+               @JsonSubTypes.Type(name = "CAST_URL", value = Request.CastUrl.class)})
 abstract class Message {
     static class Ping extends Message {}
     static class Pong extends Message {}

--- a/src/main/java/su/litvak/chromecast/api/v2/Request.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Request.java
@@ -122,7 +122,29 @@ abstract class Request extends Message {
             this.volume = volume;
         }
     }
+    
+    static class CastUrl extends Request {
+        @JsonProperty
+        private final String url;
 
+        @JsonProperty
+        private final boolean force;
+
+        @JsonProperty
+        private final boolean reload;
+   		
+        @JsonProperty("reload_time")
+        private final int reloadTime;
+
+        CastUrl(String url, boolean force, boolean reload, int reloadTime) {
+            super();
+            this.url = url;
+            this.force = force;
+            this.reload = reload;
+            this.reloadTime = reloadTime;
+        }
+    }
+    
     static Status status() {
         return new Status();
     }
@@ -157,5 +179,9 @@ abstract class Request extends Message {
 
     static SetVolume setVolume(Volume volume) {
         return new SetVolume(volume);
+    }
+    
+    static CastUrl castUrl(String url, boolean force, boolean reload, int reloadTime) {
+   	 return new CastUrl(url, force, reload, reloadTime);
     }
 }

--- a/src/main/java/su/litvak/chromecast/api/v2/Response.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Response.java
@@ -33,7 +33,8 @@ import java.util.Map;
                @JsonSubTypes.Type(name = "MEDIA_STATUS", value = Response.MediaStatus.class),
                @JsonSubTypes.Type(name = "CLOSE", value = Response.Close.class),
                @JsonSubTypes.Type(name = "LOAD_FAILED", value = Response.LoadFailed.class),
-               @JsonSubTypes.Type(name = "LAUNCH_ERROR", value = Response.LaunchError.class)})
+               @JsonSubTypes.Type(name = "LAUNCH_ERROR", value = Response.LaunchError.class),
+               @JsonSubTypes.Type(name = "CAST_URL", value = Response.CastUrl.class)})
 abstract class Response {
     @JsonProperty
     Long requestId;
@@ -80,4 +81,18 @@ abstract class Response {
         @JsonProperty
         Map<String, String> availability;
     }
+
+    static class CastUrl extends Response {
+       @JsonProperty
+       String url;
+
+       @JsonProperty
+       boolean force;
+
+       @JsonProperty
+       boolean reload;
+  		
+       @JsonProperty("reload_time")
+       int reloadTime;
+   }
 }


### PR DESCRIPTION
DashCast (https://github.com/stestagg/dashcast) is a custom receiver that allows users to stream any homepage to a ChromeCast and have it refresh headlessly (without a connected browser). The control interface is normally via the homepage (http://stestagg.github.io/dashcast/), but this PR adds programmatic support to the ChromeCast API.

I would have preferred to implement this as a separate module, but almost every class and method is private or package access only ;)