### PR TITLE
Small a to DashCast example to make it work

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ public class DashCastRequest implements Request {
 Sending request
 
 ````java
+chromecast.launchApp("5C3F0A3C");
 chromecast.send("urn:x-cast:es.offd.dashcast", new DashCastRequest("http://yandex.ru", true, false, 0));
 ````
 


### PR DESCRIPTION
The DashCast receiver must be loaded to process messages.