### PR TITLE
Method to load full Media object with custom metadata.

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
@@ -252,13 +252,12 @@ public class ChromeCast {
      * Loads and starts playing specified media
      *
      * @param media The media to load and play.  See https://developers.google.com/cast/docs/reference/messages#Load for further details.
-     * @param customData Optional application specific data.  May be null.
      * @return The new media status that resulted from loading the media.
      * @throws IOException
      */
-    public MediaStatus load(final Media media, final Map<String, String> customData) throws IOException {
+    public MediaStatus load(final Media media) throws IOException {
         Status status = getStatus();
-        return channel.load(status.getRunningApp().transportId, status.getRunningApp().sessionId, media, true, 0d, customData);
+        return channel.load(status.getRunningApp().transportId, status.getRunningApp().sessionId, media, true, 0d, null);
     }
 
     /**

--- a/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
@@ -249,6 +249,19 @@ public class ChromeCast {
     }
 
     /**
+     * Loads and starts playing specified media
+     *
+     * @param media The media to load and play.  See https://developers.google.com/cast/docs/reference/messages#Load for further details.
+     * @param customData Optional application specific data.  May be null.
+     * @return The new media status that resulted from loading the media.
+     * @throws IOException
+     */
+    public MediaStatus load(final Media media, final Map<String, String> customData) throws IOException {
+        Status status = getStatus();
+        return channel.load(status.getRunningApp().transportId, status.getRunningApp().sessionId, media, true, 0d, customData);
+    }
+
+    /**
      * <p>Sends some generic request to the currently running application.</p>
      *
      * <p>If no application is running at the moment then exception is thrown.</p>

--- a/src/main/java/su/litvak/chromecast/api/v2/Media.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Media.java
@@ -52,7 +52,7 @@ public class Media {
     @JsonProperty
     public final Double duration;
 
-    @JsonIgnore
+    @JsonProperty
     public final StreamType streamType;
 
     @JsonProperty

--- a/src/main/java/su/litvak/chromecast/api/v2/Media.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Media.java
@@ -43,13 +43,13 @@ public class Media {
         NONE, none
     }
 
-    @JsonIgnore
+    @JsonProperty
     public final Map<String, Object> metadata;
 
     @JsonProperty("contentId")
     public final String url;
 
-    @JsonIgnore
+    @JsonProperty
     public final Double duration;
 
     @JsonIgnore
@@ -58,7 +58,7 @@ public class Media {
     @JsonProperty
     public final String contentType;
 
-    @JsonIgnore
+    @JsonProperty
     public final Map<String, Object> customData;
 
     @JsonIgnore

--- a/src/main/java/su/litvak/chromecast/api/v2/Media.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Media.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.codehaus.jackson.annotate.JsonIgnore;
 /**
  * Media streamed on ChromeCast device
@@ -44,21 +45,25 @@ public class Media {
     }
 
     @JsonProperty
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
     public final Map<String, Object> metadata;
 
     @JsonProperty("contentId")
     public final String url;
 
     @JsonProperty
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
     public final Double duration;
 
     @JsonProperty
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
     public final StreamType streamType;
 
     @JsonProperty
     public final String contentType;
 
     @JsonProperty
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
     public final Map<String, Object> customData;
 
     @JsonIgnore

--- a/src/test/java/su/litvak/chromecast/api/v2/MediaTest.java
+++ b/src/test/java/su/litvak/chromecast/api/v2/MediaTest.java
@@ -1,0 +1,46 @@
+package su.litvak.chromecast.api.v2;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Test;
+
+import su.litvak.chromecast.api.v2.Media.StreamType;
+
+public class MediaTest {
+    final ObjectMapper jsonMapper = new ObjectMapper();
+
+    @Test
+    public void itIncludesOptionalFieldsWhenSet () throws Exception {
+        Map<String, Object> customData = new HashMap<String, Object>();
+        customData.put("a", "b");
+        Map<String, Object> metadata = new HashMap<String, Object>();
+        metadata.put("1", "2");
+        Media m = new Media(null, null, 123.456d, StreamType.BUFFERED, customData, metadata, null, null);
+
+        String json = jsonMapper.writeValueAsString(m);
+
+        assertThat(json, containsString("\"duration\":123.456"));
+        assertThat(json, containsString("\"streamType\":\"BUFFERED\""));
+        assertThat(json, containsString("\"customData\":{\"a\":\"b\"}"));
+        assertThat(json, containsString("\"metadata\":{\"1\":\"2\"}"));
+    }
+
+    @Test
+    public void itDoseNotContainOptionalFieldsWhenNotSet () throws Exception {
+        Media m = new Media(null, null, null, null, null, null, null, null);
+
+        String json = jsonMapper.writeValueAsString(m);
+
+        assertThat(json, not(containsString("duration")));
+        assertThat(json, not(containsString("streamType")));
+        assertThat(json, not(containsString("customData")));
+        assertThat(json, not(containsString("metadata")));
+    }
+
+}


### PR DESCRIPTION
Currently this SDK provides a `load()` method with `title` and `thumb` parameters that are passed to the ChromeCast in a `customData` parameter (as a sibling to the media field).  I can not find any documentation explaining this approach and it does not seem to have any affect on my ChromeCast.

From the SDK docs, the `load()` method [takes a MediaInformation object] (https://developers.google.com/cast/docs/reference/messages#Load) (Media in the SDK) [the parameters for which](https://developers.google.com/cast/docs/reference/messages#MediaInformation) include `metadata`, `duration` and `customData` (a different `customData` field to the one mentioned above).  However these are currently marked with `@JsonIgnore` (it is not clear why this was needed).

It would be useful to be able to specify the full `Media` object to the `load()` method and have the `metadata`, `duration` and `customData` fields included in the request.
