### PR TITLE
use ASL licensed version of jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-lgpl</artifactId>
+            <artifactId>jackson-mapper-asl</artifactId>
             <version>1.9.13</version>
         </dependency>
 


### PR DESCRIPTION
Currently the LGPL licensed version of Jackson Json-processor is used.
The library is available using the LGPL and the ASL.

See e.g. https://github.com/codehaus/jackson/tree/1.9/1.9.10

```text
=== Licensing ===

Jackson can be used for any purpose, but to (re)distribute it,
distributors
(such as libraries and frameworks that use Jackson) will need to
choose which License they want to apply to distribution, and to use
appropriate
jars that enclose license documentation.
No work needed beyond choosing the appropriate jar(s).

Currently two Open Source licenses are available for use:

* Apache License 2.0 (AL 2.0)
* Lesser/Library General Public License (LGPL 2.1)

These licenses have proven adequate to cover all current use cases.
```

The Chromecast API is using Apache License themselves, so as long as
there is no difference between the LGPL and AL version of Jackson, we
can choose the same license here.

There are licenses that allows the usage of 'Apache License' but refuse
the LGPL (e.g. https://eclipse.org/legal/eplfaq.php#3RDPARTY)

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>