### PR TITLE
add a connected event

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/ChromeCastSpontaneousEvent.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/ChromeCastSpontaneousEvent.java
@@ -7,6 +7,11 @@ public class ChromeCastSpontaneousEvent {
     public enum SpontaneousEventType {
 
         /**
+         * Data type will be {@link Boolean}.
+         */
+        CONNECTION_STATUS(Boolean.class),
+
+        /**
          * Data type will be {@link MediaStatus}.
          */
         MEDIA_STATUS(MediaStatus.class),

--- a/src/main/java/su/litvak/chromecast/api/v2/EventListenerHolder.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/EventListenerHolder.java
@@ -28,6 +28,10 @@ class EventListenerHolder implements ChromeCastSpontaneousEventListener {
 		}
 	}
 
+	public void deliverEventConnectionStatus(final boolean connected) {
+		spontaneousEventReceived(new ChromeCastSpontaneousEvent(SpontaneousEventType.CONNECTION_STATUS, connected));
+	}
+
 	public void deliverEvent (final JsonNode json) throws IOException {
 		if (json == null) return;
 		if (this.eventListeners.size() < 1) return;


### PR DESCRIPTION
The listener of the chromecast is not notified if the connection has been closed (e.g. if the read thread identify that the connection has been closed).
This will add an event if the "closed" member change the state.