### PR TITLE
Allow to receive custom events messages from a receiver app

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/AppEvent.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/AppEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 Vitaly Litvak (vitavaque@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package su.litvak.chromecast.api.v2;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+/**
+ * And custom event sent by a receiver app.
+ */
+public class AppEvent {
+    public final String namespace;
+    public final String message;
+
+    AppEvent(@JsonProperty("namespace") String namespace,
+            @JsonProperty("message") String message) {
+        this.namespace = namespace;
+        this.message = message;
+    }
+}

--- a/src/main/java/su/litvak/chromecast/api/v2/AppEvent.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/AppEvent.java
@@ -21,11 +21,12 @@ import org.codehaus.jackson.annotate.JsonProperty;
  * And custom event sent by a receiver app.
  */
 public class AppEvent {
+    @JsonProperty
     public final String namespace;
+    @JsonProperty
     public final String message;
 
-    AppEvent(@JsonProperty("namespace") String namespace,
-            @JsonProperty("message") String message) {
+    AppEvent(String namespace, String message) {
         this.namespace = namespace;
         this.message = message;
     }

--- a/src/main/java/su/litvak/chromecast/api/v2/ChromeCastSpontaneousEvent.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/ChromeCastSpontaneousEvent.java
@@ -17,6 +17,11 @@ public class ChromeCastSpontaneousEvent {
         STATUS(Status.class),
 
         /**
+         * Data type will be {@link AppEvent}.
+         */
+        APPEVENT(AppEvent.class),
+
+        /**
          * Data type will be {@link org.codehaus.jackson.JsonNode}.
          */
         UNKNOWN(JsonNode.class);

--- a/src/main/java/su/litvak/chromecast/api/v2/EventListenerHolder.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/EventListenerHolder.java
@@ -53,6 +53,10 @@ class EventListenerHolder implements ChromeCastSpontaneousEventListener {
 		}
 	}
 
+	public void deliverAppEvent (final AppEvent event) throws IOException {
+		spontaneousEventReceived(new ChromeCastSpontaneousEvent(SpontaneousEventType.APPEVENT, event));
+	}
+
 	@Override
 	public void spontaneousEventReceived (final ChromeCastSpontaneousEvent event) {
 		for (final ChromeCastSpontaneousEventListener listener : this.eventListeners) {


### PR DESCRIPTION
CastMessageBus#send and CastMessageBus#broadcast allow to send any type of
message (not just json). This code is an example of valid messages from a
custom app receiver.

var castMsgBus = castReceiverManager.getCastMessageBus('urn:x-cast:com.test');
castMsgBus.send(event.senderId, "This is the message");
var evt = "{\"responseType\":\"APPEVENT\",\"requestId\":0,\"event\":{\"msg\":\"This is the message\"}}";
castMsgBus.send(event.senderId, evt);

This patch try to determine whether and event received from a chromecast
device, and deliver it as a new spontaneous type: AppEvent. This class has
the channel namespace and the message as string received from the device.

Signed-off-by: Jorge Ruesga <jorge@ruesga.com>