### PR TITLE
title and thumb are part of the media's metadata

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
@@ -248,10 +248,10 @@ public class ChromeCast {
      */
     public MediaStatus load(String title, String thumb, String url, String contentType) throws IOException {
         Status status = getStatus();
-        Map<String, String> customData = new HashMap<String, String>(2);
-        customData.put("title:", title);
-        customData.put("thumb", thumb);
-        return channel.load(status.getRunningApp().transportId, status.getRunningApp().sessionId, new Media(url, contentType), true, 0d, customData);
+        Map<String, Object> metadata = new HashMap<String, Object>(2);
+        metadata.put("title", title);
+        metadata.put("thumb", thumb);
+        return channel.load(status.getRunningApp().transportId, status.getRunningApp().sessionId, new Media(url, contentType, null, null, null, metadata, null, null), true, 0d, null);
     }
 
     /**


### PR DESCRIPTION
... at least if the pychromecast implementation is correct.

But it seems it is correct, because:
* the title is not shown without that change
* the title is shown with that change

With respect to: https://github.com/vitalidze/chromecast-java-api-v2/pull/38#issuecomment-256162377