### PR TITLE
fix potential null pointer access

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/Channel.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Channel.java
@@ -132,11 +132,13 @@ class Channel implements Closeable {
 
                         // Determine whether the message belongs to cast protocol or is a custom
                         // message from the receiver app
-                        JsonNode parsed = null;
+                        final JsonNode parsed;
                         try {
                             parsed = jsonMapper.readTree(jsonMSG);
                         } catch (JsonProcessingException jpex) {
                             // Ignore
+                            // To prevent potential null pointer access using parsed, we could continue...
+                            continue;
                         }
 
                         if (isAppEvent(parsed)) {


### PR DESCRIPTION
e.g. `parsed.has("requestId")` will raise a NPE if the exception has been catched