### PR TITLE
Information hiding for JmDNS

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
@@ -37,7 +37,7 @@ public class ChromeCast {
     private String application;
     private Channel channel;
 
-    public ChromeCast(JmDNS mDNS, String name) {
+    ChromeCast(JmDNS mDNS, String name) {
         this.name = name;
         ServiceInfo serviceInfo = mDNS.getServiceInfo(SERVICE_TYPE, name);
         this.address = serviceInfo.getInet4Addresses()[0].getHostAddress();


### PR DESCRIPTION
The usage of JmDNS is an implementation detail and should not be exposed to the API

This breaks the API a little, but I think it's worth it. The JmDNS object exposes how the discovery is done. This should stay the implementation secret of the library.
What do you think? 