### PR TITLE
Added Travis CI build status for more transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-ChromeCast Java API v2
+ChromeCast Java API v2 [![Build Status](https://travis-ci.org/sfuhrm/html2sax.svg?branch=master)](https://travis-ci.org/vitalidze/chromecast-java-api-v2)
 ======================
 
 At the moment I have started implementing this library, there was a java [implementation of V1 Google ChromeCast protocol](https://github.com/entertailion/Caster), which seems to be deprecated and does not work for newly created applications. The new V2 protocol is implemented by tools that come with Cast SDK, which is available for Android, iOS and Chrome Extension as javascript. Also there is a third party [implementation of V2 in Node.js](https://github.com/vincentbernat/nodecastor). This project is a third party implementation of Google ChromeCast V2 protocol in java.


### PR DESCRIPTION
Small change proposal to the readme: Shows now the Travis CI build image on the landing page of Github.