### PR TITLE
Ignore json errors and reconect on Socket errors

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/Channel.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Channel.java
@@ -20,6 +20,7 @@ import static su.litvak.chromecast.api.v2.Util.toArray;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.annotate.JsonSubTypes;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -30,6 +31,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.SocketException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.security.GeneralSecurityException;

--- a/src/main/java/su/litvak/chromecast/api/v2/Channel.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Channel.java
@@ -173,6 +173,18 @@ class Channel implements Closeable {
                     }
                 } catch (InvalidProtocolBufferException ipbe) {
                     LOG.debug("Error while processing protobuf: {}", ipbe.getLocalizedMessage());
+                } catch (JsonParseException jpe) {
+                    LOG.warn("Error while processing protobuf: {}", jpe.getLocalizedMessage());
+                } catch (SocketException se) {
+                    LOG.warn("Socket error, will reconnect: {}", se.getLocalizedMessage());
+                    LOG.debug("StackTrace", se);
+                    try {
+                        close();
+                        connect();
+                    } catch (Exception e) {
+                        LOG.warn("Error while reconnecting channel: {}", e.getLocalizedMessage());
+                        LOG.debug("StackTrace", e);
+                    }
                 } catch (IOException ioex) {
                     LOG.warn("Error while reading: {}", ioex.getLocalizedMessage());
                     String temp;


### PR DESCRIPTION
My Chromecasts just stays offline after a socket error, so this approach will allow for a reconnect.