### PR TITLE
Always feed MEDIA_STATUS to spontaneous event listeners

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/Channel.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Channel.java
@@ -162,6 +162,8 @@ class Channel implements Closeable {
                                         LOG.warn("Unable to process request ID = {}, data: {}", requestId, jsonMSG);
                                     }
                                 }
+                            } else if (parsed.has("responseType") && parsed.get("responseType").asText().equals("MEDIA_STATUS")) {
+                                notifyListenersOfSpontaneousEvent(parsed);
                             } else if (parsed.has("responseType") && parsed.get("responseType").asText().equals("PING")) {
                                 write("urn:x-cast:com.google.cast.tp.heartbeat", StandardMessage.pong(), DEFAULT_RECEIVER_ID);
                             } else if (parsed.has("responseType") && parsed.get("responseType").asText().equals("CLOSE")) {


### PR DESCRIPTION
My ChromeCast is constantly (1/sec) sending media status messages, may as well use them to update the status of whatever is listening.