### PR TITLE
Handle IOException properly, while closing SSL socket

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/Channel.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Channel.java
@@ -149,6 +149,10 @@ class Channel implements Closeable {
                 } catch (JsonProcessingException jpe) {
                     LOG.warn("Error while processing json", jpe);
                 } catch (IOException ioex) {
+                    if (stop) {
+                        LOG.warn("Got IOException while reading due to stream being closed (stop=true)");
+                        continue;
+                    }
                     LOG.warn("Error while reading", ioex);
                     String temp;
                     if (message != null &&  message.getPayloadUtf8() != null) {


### PR DESCRIPTION
One minor issue (or inconvenience) I bumped into - IOException, when I try to disconnect ChromeCast object. 

Brief debug got me to the point, that the SSL Socket is closed in the Channel.java, while corresponding InputStream is waiting for read() operation. Even though the "stop" flag in the ReadThread class instance is set, the run method never gets to "while (!stop)" check due to IOException caused by socket.close().