### PR TITLE
Expose namespace names for public access

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/Namespace.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Namespace.java
@@ -21,7 +21,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
  * Namespace of the ChromeCast application.
  */
 public class Namespace {
-    final String name;
+    public final String name;
 
     public Namespace(@JsonProperty("name") String name) {
         this.name = name;


### PR DESCRIPTION
## Description
Currently there's no way to read the original namespace name from the Namespace objects.