### PR TITLE
Suport for sending raw cast requests

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
@@ -498,6 +498,25 @@ public class ChromeCast {
     }
 
     /**
+     * <p>Sends a raw JSON request to the currently running application.</p>
+     *
+     * <p>If no application is running at the moment then exception is thrown.</p>
+     *
+     * @param namespace         request namespace
+     * @param message           request message
+     * @throws IOException
+     */
+    public final void sendRawRequest(String namespace, String message, long requestId)
+            throws IOException {
+        Status status = getStatus();
+        Application runningApp = status.getRunningApp();
+        if (runningApp == null) {
+            throw new ChromeCastException("No application is running in ChromeCast");
+        }
+        channel().sendRawRequest(runningApp.transportId, namespace, message, requestId);
+    }
+
+    /**
      * <p>Sends some generic request to the currently running application.
      * No response is expected as a result of this call.</p>
      *
@@ -525,6 +544,14 @@ public class ChromeCast {
 
     public final void unregisterConnectionListener(ChromeCastConnectionEventListener listener) {
         this.eventListenerHolder.unregisterConnectionListener(listener);
+    }
+
+    public final void registerRawMessageListener(ChromeCastRawMessageListener listener) {
+        this.eventListenerHolder.registerRawMessageListener(listener);
+    }
+
+    public final void unregisterRawMessageListener(ChromeCastRawMessageListener listener) {
+        this.eventListenerHolder.unregisterRawMessageListener(listener);
     }
 
     @Override

--- a/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
@@ -271,6 +271,16 @@ public class ChromeCast {
     }
 
     /**
+     * <p>Stops the session with the given identifier.</p>
+     *
+     * @param sessionId    session identifier
+     * @throws IOException
+     */
+    public final void stopSession(String sessionId) throws IOException {
+        channel().stop(sessionId);
+    }
+
+    /**
      * @param level volume level from 0 to 1 to set
      */
     public final void setVolume(float level) throws IOException {

--- a/src/main/java/su/litvak/chromecast/api/v2/ChromeCastRawMessage.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/ChromeCastRawMessage.java
@@ -34,6 +34,10 @@ public final class ChromeCastRawMessage {
         return this.message.getPayloadUtf8();
     }
 
+    public byte[] getPayloadBinary() {
+        return this.message.getPayloadBinary().toByteArray();
+    }
+
     public String getNamespace() {
         return this.message.getNamespace();
     }

--- a/src/main/java/su/litvak/chromecast/api/v2/ChromeCastRawMessage.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/ChromeCastRawMessage.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 Vitaly Litvak (vitavaque@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package su.litvak.chromecast.api.v2;
+
+/**
+ * <p>Identifies that a raw message was received from a ChromeCast device.</p>
+ */
+public final class ChromeCastRawMessage {
+
+    private final CastChannel.CastMessage message;
+
+    public ChromeCastRawMessage(CastChannel.CastMessage message) {
+        this.message = message;
+    }
+
+    public CastChannel.CastMessage.PayloadType getPayloadType() {
+        return this.message.getPayloadType();
+    }
+
+    public String getPayloadUtf8() {
+        return this.message.getPayloadUtf8();
+    }
+
+    public String getNamespace() {
+        return this.message.getNamespace();
+    }
+}

--- a/src/main/java/su/litvak/chromecast/api/v2/ChromeCastRawMessageListener.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/ChromeCastRawMessageListener.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 Vitaly Litvak (vitavaque@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package su.litvak.chromecast.api.v2;
+
+/**
+ * The listener interface for receiving raw messages. The class that is interested in processing raw
+ * messages implements this interface, and object create with that class is registered with <code>ChromeCast</code>
+ * instance using the <code>registerRawMessageListener</code> method. When messages are received, that object's
+ * <code>rawMessageReceived</code> is invoked.
+ */
+public interface ChromeCastRawMessageListener {
+
+    void rawMessageReceived(ChromeCastRawMessage message, Long requestId);
+
+}

--- a/src/main/java/su/litvak/chromecast/api/v2/EventListenerHolder.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/EventListenerHolder.java
@@ -26,13 +26,18 @@ import java.util.concurrent.CopyOnWriteArraySet;
 /**
  * Helper class for delivering spontaneous events to their listeners.
  */
-class EventListenerHolder implements ChromeCastSpontaneousEventListener, ChromeCastConnectionEventListener {
+class EventListenerHolder implements
+    ChromeCastSpontaneousEventListener,
+    ChromeCastConnectionEventListener,
+    ChromeCastRawMessageListener {
 
     private final ObjectMapper jsonMapper = JacksonHelper.createJSONMapper();
     private final Set<ChromeCastSpontaneousEventListener> eventListeners =
             new CopyOnWriteArraySet<ChromeCastSpontaneousEventListener>();
     private final Set<ChromeCastConnectionEventListener> eventListenersConnection =
             new CopyOnWriteArraySet<ChromeCastConnectionEventListener>();
+    private final Set<ChromeCastRawMessageListener> rawMessageListeners =
+            new CopyOnWriteArraySet<ChromeCastRawMessageListener>();
 
     EventListenerHolder() {}
 
@@ -107,6 +112,25 @@ class EventListenerHolder implements ChromeCastSpontaneousEventListener, ChromeC
     public void connectionEventReceived(ChromeCastConnectionEvent event) {
         for (ChromeCastConnectionEventListener listener : this.eventListenersConnection) {
             listener.connectionEventReceived(event);
+        }
+    }
+
+    public void registerRawMessageListener(ChromeCastRawMessageListener listener) {
+        if (listener != null) {
+            this.rawMessageListeners.add(listener);
+        }
+    }
+
+    public void unregisterRawMessageListener(ChromeCastRawMessageListener listener) {
+        if (listener != null) {
+            this.rawMessageListeners.remove(listener);
+        }
+    }
+
+    @Override
+    public void rawMessageReceived(ChromeCastRawMessage message, Long requestId) {
+        for (ChromeCastRawMessageListener listener : this.rawMessageListeners) {
+            listener.rawMessageReceived(message, requestId);
         }
     }
 }

--- a/src/test/java/su/litvak/chromecast/api/v2/RawRequestTest.java
+++ b/src/test/java/su/litvak/chromecast/api/v2/RawRequestTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Vitaly Litvak (vitavaque@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package su.litvak.chromecast.api.v2;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+public class RawRequestTest {
+    MockedChromeCast chromeCastStub;
+    ChromeCast cast = new ChromeCast("localhost");
+
+    @Before
+    public void init() throws IOException, GeneralSecurityException {
+        chromeCastStub = new MockedChromeCast();
+        cast.connect();
+        cast.launchApp("KIOSK");
+    }
+
+    @After
+    public void destroy() throws IOException {
+        cast.disconnect();
+        chromeCastStub.close();
+    }
+
+    @Test
+    public void test() throws IOException {
+        chromeCastStub.rawRequestHandler = new MockedChromeCast.RawRequestHandler() {
+            @Override
+            public String handle(String message) {
+                return "{\"mockRawResponse\": \"mockRawResponseValue\",\"requestId\": 1}";
+            }
+        };
+
+        cast.sendRawRequest("urn:x-cast:de.michaelkuerbis.kiosk",
+                "{\"mockRawRequest\": \"mockRawValue\", \"requestId\": 1}", 1);
+    }
+}


### PR DESCRIPTION
## Description
This PR adds a new method to support sending raw requests of pre-serialized JSON, and returns the raw JSON string as the response. I doubt this is a common use case, but would be necessary to make use of this lib with microG. In this environment, Google's SDK has already serialized the request that it wants to make, and already is equipped to parse the response.

Intended usage is here: https://github.com/microg/android_packages_apps_GmsCore/pull/555/files#diff-dd605a7b4a2ad9bbac1db8fc15690fa1R85