### PR TITLE
Throw ChromeCastException when interrupted or timeout occurs

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/Channel.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Channel.java
@@ -234,7 +234,7 @@ class Channel implements Closeable {
             }
         }
 
-        public T get() {
+        public T get() throws IOException {
             synchronized (this) {
                 if (result != null) {
                     return result;
@@ -242,7 +242,10 @@ class Channel implements Closeable {
                 try {
                     this.wait(REQUEST_TIMEOUT);
                 } catch (InterruptedException ie) {
-                    ie.printStackTrace();
+                    throw new ChromeCastException("Interrupted while waiting for response", ie);
+                }
+                if (result == null) {
+                    throw new ChromeCastException("Timeout occurred while waiting for response");
                 }
                 return result;
             }


### PR DESCRIPTION
We use this nice library with openHAB but each time I stop the runtime several of these stack traces are printed:

```
java.lang.InterruptedException
	at java.lang.Object.wait(Native Method)
	at su.litvak.chromecast.api.v2.Channel$ResultProcessor.get(Channel.java:243)
	at su.litvak.chromecast.api.v2.Channel.send(Channel.java:371)
	at su.litvak.chromecast.api.v2.Channel.sendStandard(Channel.java:340)
	at su.litvak.chromecast.api.v2.Channel.getMediaStatus(Channel.java:512)
	at su.litvak.chromecast.api.v2.ChromeCast.getMediaStatus(ChromeCast.java:321)
	at org.openhab.binding.chromecast.internal.ChromecastCommander.handleRefresh(ChromecastCommander.java:102)
	at org.openhab.binding.chromecast.handler.ChromecastHandler$Coordinator$1.run(ChromecastHandler.java:231)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

This PR fixes that by logging the InterruptedException on debug.