### PR TITLE
Fix slf4j version range in POM so manifest uses [1.7,2) version range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson.version>[2.8.11,2.9.8]</jackson.version>
+        <slf4j.version>[1.7.2,1.7.100]</slf4j.version>
     </properties>
 
     <dependencies>
@@ -57,7 +58,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>[1.7.2,1.8)</version>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>
@@ -70,7 +71,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.8.0-beta2</version>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Because of the version ranges used in the POM slf4j version 1.8.0-beta4 is resolved during builds. 

As a result the manifest contains:

`org.slf4j;version="[1.8,2)"`

With this PR only 1.7.x versions are resolved so the manifest contains:

`org.slf4j;version="[1.7,2)"`

This way usage of the 1.8.0 beta version is no longer forced when using the bundle with OSGi.