### PR TITLE
Updated version constraint of Jackson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson.version>[2.8.11,2.9.9]</jackson.version>
+        <jackson.version>[2.8.11,2.10.0)</jackson.version>
         <slf4j.version>[1.7.2,1.7.100]</slf4j.version>
         <checkstyle.plugin.version>3.0.0</checkstyle.plugin.version>
         <checkstyle.version>8.19</checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson.version>[2.8.11,2.9.8]</jackson.version>
+        <jackson.version>[2.8.11,2.9.9]</jackson.version>
         <slf4j.version>[1.7.2,1.7.100]</slf4j.version>
         <checkstyle.plugin.version>3.0.0</checkstyle.plugin.version>
         <checkstyle.version>8.19</checkstyle.version>


### PR DESCRIPTION
- Updated version constraint of Jackson dependency

We like to use a streamlined Jackson version (2.9.9) in openHAB Core and all of its add-ons (see https://github.com/openhab/openhab-core/issues/892#issuecomment-520141490).

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>