### PR TITLE
Cleanup ChromeCasts.get() from previous discoveries

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/ChromeCasts.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/ChromeCasts.java
@@ -92,6 +92,8 @@ public final class ChromeCasts {
 
     private void doStartDiscovery(InetAddress addr) throws IOException {
         if (mDNS == null) {
+            chromeCasts.clear();
+
             if (addr != null) {
                 mDNS = JmDNS.create(addr);
             } else {


### PR DESCRIPTION
When a discovery completes, the discovered chromecasts are still accessible in the `ChromeCasts.get()` device list, and this is ok. But if the discovery is run again the device list could contain duplicate items, since the items from the previous discovery could not have expired yet. The code in this pr clears the device list before starting another discovery.