### PR TITLE
Added handling for responseType 'LOAD_CANCELLED'

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/Channel.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Channel.java
@@ -380,7 +380,7 @@ class Channel implements Closeable {
             if (response instanceof StandardResponse.Invalid) {
                 StandardResponse.Invalid invalid = (StandardResponse.Invalid) response;
                 throw new ChromeCastException("Invalid request: " + invalid.reason);
-            } else if (response instanceof StandardResponse.LoadFailed) {
+            } else if (response instanceof StandardResponse.LoadCancelled || response instanceof StandardResponse.LoadFailed) {
                 throw new ChromeCastException("Unable to load media");
             } else if (response instanceof StandardResponse.LaunchError) {
                 StandardResponse.LaunchError launchError = (StandardResponse.LaunchError) response;

--- a/src/main/java/su/litvak/chromecast/api/v2/StandardResponse.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/StandardResponse.java
@@ -33,6 +33,7 @@ import java.util.Map;
                @JsonSubTypes.Type(name = "MEDIA_STATUS", value = StandardResponse.MediaStatus.class),
                @JsonSubTypes.Type(name = "MULTIZONE_STATUS", value = StandardResponse.MultizoneStatus.class),
                @JsonSubTypes.Type(name = "CLOSE", value = StandardResponse.Close.class),
+               @JsonSubTypes.Type(name = "LOAD_CANCELLED", value = StandardResponse.LoadCancelled.class),
                @JsonSubTypes.Type(name = "LOAD_FAILED", value = StandardResponse.LoadFailed.class),
                @JsonSubTypes.Type(name = "LAUNCH_ERROR", value = StandardResponse.LaunchError.class),
                @JsonSubTypes.Type(name = "DEVICE_ADDED", value = StandardResponse.DeviceAdded.class),
@@ -65,6 +66,11 @@ abstract class StandardResponse implements Response {
      * Request to 'Close' connection.
      */
     static class Close extends StandardResponse {}
+
+    /**
+     * Identifies that loading of media has been cancelled.
+     */
+    static class LoadCancelled extends StandardResponse {}
 
     /**
      * Identifies that loading of media has failed.


### PR DESCRIPTION
- Added handling for responseType 'LOAD_CANCELLED'

Prevents warnings like these:

```
2020-05-07 17:00:02.993 [WARN ] [su.litvak.chromecast.api.v2.Channel ] - Error while handling, caused by com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve type id 'LOAD_CANCELLED' as a subtype of [simple type, class su.litvak.chromecast.api.v2.StandardResponse]: known type ids = [CLOSE, DEVICE_ADDED, DEVICE_REMOVED, DEVICE_UPDATED, GET_APP_AVAILABILITY, INVALID_REQUEST, LAUNCH_ERROR, LOAD_FAILED, MEDIA_STATUS, MULTIZONE_STATUS, PING, PONG, RECEIVER_STATUS]
 at [Source: (String)"{"requestId":5001,"responseType":"LOAD_CANCELLED","itemId":1}"; line: 1, column: 34]
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>