### PR TITLE
Support passing customData to media load request

### DIFF
--- a/src/main/java/su/litvak/chromecast/api/v2/Channel.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/Channel.java
@@ -490,7 +490,7 @@ class Channel implements Closeable {
         }
     }
 
-    public MediaStatus load(String destinationId, String sessionId, Media media, boolean autoplay, double currentTime, Map<String, String> customData) throws IOException {
+    public MediaStatus load(String destinationId, String sessionId, Media media, boolean autoplay, double currentTime, Object customData) throws IOException {
         startSession(destinationId);
         StandardResponse.MediaStatus status = sendStandard("urn:x-cast:com.google.cast.media", StandardRequest.load(sessionId, media, autoplay, currentTime, customData), destinationId);
         return status == null || status.statuses.length == 0 ? null : status.statuses[0];

--- a/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/ChromeCast.java
@@ -432,15 +432,10 @@ public class ChromeCast {
      * @throws IOException
      */
     public final MediaStatus load(String mediaTitle, String thumb, String url, String contentType) throws IOException {
-        Status status = getStatus();
-        Application runningApp = status.getRunningApp();
-        if (runningApp == null) {
-            throw new ChromeCastException("No application is running in ChromeCast");
-        }
         Map<String, Object> metadata = new HashMap<String, Object>(2);
         metadata.put("title", mediaTitle);
         metadata.put("thumb", thumb);
-        return channel().load(getTransportId(runningApp), runningApp.sessionId, new Media(url,
+        return load(new Media(url,
                 contentType == null ? getContentType(url) : contentType, null, null, null,
                 metadata, null, null), true, 0d, null);
     }
@@ -457,6 +452,25 @@ public class ChromeCast {
      * @throws IOException
      */
     public final MediaStatus load(final Media media) throws IOException {
+        return load(media, true, 0d, null);
+    }
+
+    /**
+     * <p>Loads and starts playing specified media</p>
+     *
+     * <p>If no application is running at the moment then exception is thrown.</p>
+     *
+     * @param media The media to load and play.
+     *              See <a href="https://developers.google.com/cast/docs/reference/messages#Load">
+     *                  https://developers.google.com/cast/docs/reference/messages#Load</a> for more details.
+     * @param autoplay whether the media should start playing when loaded
+     * @param currentTime seconds since beginning of content
+     * @param customData Application-specific data
+     * @return The new media status that resulted from loading the media.
+     * @throws IOException
+     */
+    public final MediaStatus load(final Media media, boolean autoplay, double currentTime,
+            Object customData) throws IOException {
         Status status = getStatus();
         Application runningApp = status.getRunningApp();
         if (runningApp == null) {
@@ -469,7 +483,8 @@ public class ChromeCast {
         } else {
             mediaToPlay = media;
         }
-        return channel().load(getTransportId(runningApp), runningApp.sessionId, mediaToPlay, true, 0d, null);
+        return channel().load(getTransportId(runningApp), runningApp.sessionId, mediaToPlay, autoplay, currentTime,
+                customData);
     }
 
     /**

--- a/src/main/java/su/litvak/chromecast/api/v2/StandardRequest.java
+++ b/src/main/java/su/litvak/chromecast/api/v2/StandardRequest.java
@@ -17,8 +17,6 @@ package su.litvak.chromecast.api.v2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Map;
-
 /**
  * Parent class for transport object representing messages sent TO ChromeCast device.
  */
@@ -91,17 +89,12 @@ abstract class StandardRequest extends StandardMessage implements Request {
         @JsonProperty
         final Object customData;
 
-        Load(String sessionId, Media media, boolean autoplay, double currentTime,
-             final Map<String, String> customData) {
+        Load(String sessionId, Media media, boolean autoplay, double currentTime, Object customData) {
             this.sessionId = sessionId;
             this.media = media;
             this.autoplay = autoplay;
             this.currentTime = currentTime;
-
-            this.customData = customData == null ? null : new Object() {
-                @JsonProperty
-                Map<String, String> payload = customData;
-            };
+            this.customData = customData;
         }
     }
 
@@ -180,7 +173,7 @@ abstract class StandardRequest extends StandardMessage implements Request {
     }
 
     static Load load(String sessionId, Media media, boolean autoplay, double currentTime,
-                     Map<String, String> customData) {
+                     Object customData) {
         return new Load(sessionId, media, autoplay, currentTime, customData);
     }
 


### PR DESCRIPTION
There are two issues here:

* `ChromeCast.load` did not allow passing a `customData` parameter
* The `customData` serialiser assumed an object with property `payload` containing an object with only string values.

From the documentation (https://developers.google.com/cast/docs/media/messages#Load):

> Name | Type | Description
> -- | -- | --
> customData | object | optional Application-specific blob of data defined by the sender application

There shouldn't be any assumptions about how this is serialised, so providing an `Object` gives the caller the greatest flexibility.

Given that the functions to construct the `StandardRequest.Load` object are package-private and that no public method exists to set `customData`, I believe it's unlikely anyone is relying on the existing serialisation (i.e. wrapped in an object property `payload`).

Use case: When reverse engineering the Soundcloud client controller in Chrome, I found it required a `customData` object on the `LOAD` event, which I could not set with this library without resorting to reflection.